### PR TITLE
Fix ingress service name

### DIFF
--- a/charts/castled/templates/webapp/ingress.yaml
+++ b/charts/castled/templates/webapp/ingress.yaml
@@ -53,7 +53,7 @@ spec:
                 port:
                   number: {{ $svcPort }}
               {{- else }}
-              serviceName: {{ $fullName }}
+              serviceName: {{ $fullName }}-webapp-service
               servicePort: {{ $svcPort }}
               {{- end }}
           {{- end }}


### PR DESCRIPTION
Ingress does not currently connect to the service since the service name has a "-webapp-service" hardcoded in the chart